### PR TITLE
feat(#12): 메인 <-> 공연 이동 구현

### DIFF
--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -1,10 +1,10 @@
 // app/event/[eventId]/page.tsx
 
 import EnsembleInfoSection from "@/components/ensemble/EnsembleInfoSection";
+import ConcertInfoSection from "@/components/concert/concertInfoSection";
 import BackToMainButton from "@/components/common/BackToMainButton";
 import { notFound } from "next/navigation";
-import { mockEvents } from "@/mocks/events_mock";
-import { mockParticipants, mockComments } from "@/mocks/ensemble_detail";
+import { mockEvents, mockParticipants, mockComments, mockConcert, mockConcertDetails } from "@/mocks/events_mock";
 
 export default async function EventDetailPage({
     params,
@@ -12,22 +12,39 @@ export default async function EventDetailPage({
     params: Promise<{ eventId: string }>;
 }) {
     const { eventId } = await params; // ✅ 핵심
-
+  // 공연과 합주를 구분
     const ensemble = mockEvents.find((e) => e.id === eventId);
-    if (!ensemble) notFound();
+    const concert = mockConcert.find((c) => c.id === eventId);
+    
+    const concertDetail = mockConcertDetails.find(
+      (d) => d.concert.id === eventId
+    );
+        if (!ensemble && !concert) notFound();
 
     const participants = mockParticipants.filter((p) => p.event_id === eventId);
     const comments = mockComments.filter((c) => c.event_id === eventId);
 
-  return (
-    <main className="mx-auto max-w-3xl p-6">
-      <EnsembleInfoSection ensemble={ensemble} participants={participants}/>
-      <BackToMainButton />
-    </main>
-  );
+return (
+  <main className="mx-auto max-w-3xl p-6">
+    {ensemble ? (
+      <EnsembleInfoSection
+        ensemble={ensemble}
+        participants={participants}
+      />
+    ) : (
+      <ConcertInfoSection 
+        concert={concertDetail!.concert}
+        setList={concertDetail!.setList}
+        memo={concertDetail!.memo} />
+    )}
+    <BackToMainButton />
+  </main>
+);
 }
 
 export function generateStaticParams() {
-  return mockEvents.map((e) => ({ eventId: e.id }));
+  return [
+    ...mockEvents.map((e) => ({ eventId: e.id })),
+    ...mockConcertDetails.map((d) => ({ eventId: d.concert.id })),
+  ];
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
       <header className="flex items-center justify-between px-4 py-2 md:px-6 md:py-4 bg-[#1a1a1a] border-b border-gray-800 flex-shrink-0 relative z-40">
         <h1 className="text-xl font-bold text-gray-100 flex items-center gap-2">
           <span className="md:hidden">📅 예약 시스템</span>
-          <span className="hidden md:inline">📅 동아리방 예약 시스템</span>
+          <span className="hidden md:inline">📅 미케닉스 스케쥴러</span>
         </h1>
         <button
           className="md:hidden p-2 text-gray-300 hover:text-white"

--- a/src/components/concert/concertInfoSection.tsx
+++ b/src/components/concert/concertInfoSection.tsx
@@ -18,7 +18,7 @@ import {
 
 type Props = {
   concert: Concert;
-  setList: SetListItem[];
+  setList?: SetListItem[];
   memo?: string;
 };
 

--- a/src/components/ensemble/EnsembleInfoSection.tsx
+++ b/src/components/ensemble/EnsembleInfoSection.tsx
@@ -1,7 +1,7 @@
 // src/components/ensemble/ensembleInfoSection.tsx
 "use client"
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import type { Ensemble, Participant } from "@/types/ensemble_detail";
 import { 
   Calendar, 

--- a/src/hooks/useReservations.ts
+++ b/src/hooks/useReservations.ts
@@ -2,22 +2,35 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/utils/supabase";
 import { Reservation } from "@/types";
 import { formatToDbDate } from "@/utils/date";
-import { mockEvents } from "@/mocks/events_mock"; 
+import { mockEvents, mockConcert } from "@/mocks/events_mock"; 
 import type { Ensemble } from "@/types/ensemble_detail";
+import type { Concert } from "@/types/concert_detail";
 
 
 const USE_MOCK = true;
 
-const mockUserName = "노윤지"; // 모달에 보여줄 임시 예약자
+const mockUserName = "장혁재"; // 모달에 보여줄 임시 예약자
 
 const ensembleToReservation = (e: Ensemble): Reservation => ({
   id: e.id,
   user_name: mockUserName,
-  purpose: e.title,          // UI의 '목적/예약명'에 합주 제목 넣기
+  purpose: e.title,
+  kind: "ensemble",
   date: e.date,
   start_time: e.start_time,
   end_time: e.end_time,
   created_at: e.created_at,
+});
+
+const concertToReservation = (c: Concert): Reservation => ({
+  id: c.id,
+  user_name: mockUserName,
+  purpose: `🌟 ${c.title}`,
+  kind: "concert",
+  date: c.date,
+  start_time: c.start_time,
+  end_time: c.end_time,
+  created_at: c.created_at,
 });
 
 
@@ -35,9 +48,15 @@ export const useReservations = (startDate: Date, endDate: Date) => {
         const start = formatToDbDate(startDate);
         const end = formatToDbDate(endDate);
 
-        return mockEvents
+        return [ 
+          ...mockEvents
           .filter((e) => e.date >= start && e.date <= end)
-          .map(ensembleToReservation);
+          .map(ensembleToReservation),
+
+          ...mockConcert
+          .filter((c) => c.date >= start && c.date <= end)
+          .map(concertToReservation),
+        ];
       }
 
       const { data, error } = await supabase
@@ -60,11 +79,12 @@ export const useUpcomingReservations = () => {
     queryFn: async () => {
       if (USE_MOCK) {
         const today = formatToDbDate(new Date());
-        return mockEvents
-          .filter((e) => e.date >= today)
+        return [
+          ...mockEvents.filter((e) => e.date >= today).map(ensembleToReservation),
+          ...mockConcert.filter((c) => c.date >= today).map(concertToReservation),
+        ]
           .sort((a, b) => (a.date + a.start_time).localeCompare(b.date + b.start_time))
-          .slice(0, 20)
-          .map(ensembleToReservation);
+          .slice(0, 20);
       }
 
       const today = formatToDbDate(new Date());
@@ -135,10 +155,11 @@ export const useAllUpcomingReservations = () => {
     queryFn: async () => {
       if (USE_MOCK) {
         const today = formatToDbDate(new Date());
-        return mockEvents
-          .filter((e) => e.date >= today)
-          .sort((a, b) => (a.date + a.start_time).localeCompare(b.date + b.start_time))
-          .map(ensembleToReservation);
+
+        return [
+          ...mockEvents.filter((e) => e.date >= today).map(ensembleToReservation),
+          ...mockConcert.filter((c) => c.date >= today).map(concertToReservation),
+        ].sort((a, b) => (a.date + a.start_time).localeCompare(b.date + b.start_time));
       }
       const today = formatToDbDate(new Date());
       const { data, error } = await supabase

--- a/src/mocks/ensemble_detail.ts
+++ b/src/mocks/ensemble_detail.ts
@@ -1,9 +1,0 @@
-import type { Participant, Comment } from "@/types/ensemble_detail"; 
-export const mockParticipants: Participant[] = [ 
-    { id: "u1",event_id: "evt_001", name: "재훈", instrument: "Bass" }, 
-    { id: "u2", event_id: "evt_002", name: "민지", instrument: "Vocal" }, 
-    { id: "u3", event_id: "evt_003", name: "서준", instrument: "Guitar" }, 
-]; 
-export const mockComments: Comment[] = [
-    { id: "c1", event_id: "evt_001", content: "튜닝 해라", created_at: new Date().toISOString(), },
-];

--- a/src/mocks/events_mock.ts
+++ b/src/mocks/events_mock.ts
@@ -1,5 +1,6 @@
 // src/mocks/events_mock.ts
-import type { Ensemble } from "@/types/ensemble_detail";
+import type { Ensemble, Participant, Comment } from "@/types/ensemble_detail";
+import type { Concert, ConcertDetail } from "@/types/concert_detail";
 
 export const mockEvents: Ensemble[] = [
   {
@@ -61,5 +62,45 @@ export const mockEvents: Ensemble[] = [
     location: "동아리방 401호",
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
+  },
+];
+
+export const mockParticipants: Participant[] = [ 
+    { id: "u1",event_id: "evt_001", name: "재훈", instrument: "Bass" }, 
+    { id: "u2", event_id: "evt_002", name: "민지", instrument: "Vocal" }, 
+    { id: "u3", event_id: "evt_003", name: "서준", instrument: "Guitar" }, 
+]; 
+export const mockComments: Comment[] = [
+    { id: "c1", event_id: "evt_001", content: "튜닝 해라", created_at: new Date().toISOString(), },
+];
+
+export const mockConcert: Concert[] = [
+  {
+    id: "concert_001",
+    title: "정기 공연",
+
+    date: "2026-02-12",
+    start_time: "18:00",
+    end_time: "21:00",
+
+    rehearsal_start_time: "13:00",
+    rehearsal_end_time: "17:00",
+
+    location: "The Vinyl Underground",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+];
+
+export const mockConcertDetails: ConcertDetail[] = [
+  {
+    concert: mockConcert[0],
+    teams: [],
+    setList: [
+      { id: "sl_001", order: 1, title: "Opening" },
+      { id: "sl_002", order: 2, title: "Smells Like Teen Spirit", note: "Drop D 튜닝" },
+      { id: "sl_003", order: 3, title: "Yellow" },
+    ],
+    memo: "뒷풀이 장소: 느그집",
   },
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Reservation {
   date: string; // 'YYYY-MM-DD' 형식
   start_time: string; // 'HH:mm' 형식
   end_time: string; // 'HH:mm' 형식
+  kind?: "ensemble" | "concert";
   created_at: string;
 }
 


### PR DESCRIPTION
- 메인 캘린더에 공연 일정 뜨게 함 
- 전부 mock 데이터임에 주의
- 공연 / 합주를 id로 구분하여 각각의 상세 페이지로 이동하게 함